### PR TITLE
A few enhancements:

### DIFF
--- a/upload.js
+++ b/upload.js
@@ -72,6 +72,7 @@ RetryHandler.prototype.getRandomInt_ = function(min, max) {
  * @param {string} [options.contentType] Content-type, if overriding the type of the blob.
  * @param {object} [options.metadata] File metadata
  * @param {function} [options.onComplete] Callback for when upload is complete
+ * @param {function} [options.onProgress] Callback for status for the in-progress upload
  * @param {function} [options.onError] Callback if upload fails
  */
 var MediaUploader = function(options) {


### PR DESCRIPTION
- Add in an onProgress listener for uploads.
- Properly trigger the onError callback when initial metadata submission fails.
- Added in a baseUrl option to override the default Drive-centric base URL. This makes this class usable with, e.g., YouTube API uploads, or theoretically any modern Google API that supports uploads.
